### PR TITLE
Compliance with Apple docs

### DIFF
--- a/SDCloudUserDefaults/SDCloudUserDefaults.m
+++ b/SDCloudUserDefaults/SDCloudUserDefaults.m
@@ -64,14 +64,27 @@
                                                       object:[NSUbiquitousKeyValueStore defaultStore]
                                                        queue:nil
                                                   usingBlock:^(NSNotification* notification) {
-                                                      NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
-                                                      NSUbiquitousKeyValueStore* cloud = [NSUbiquitousKeyValueStore defaultStore];
-                                                      NSArray* changedKeys = [notification.userInfo objectForKey:NSUbiquitousKeyValueStoreChangedKeysKey];
-                                                      for (NSString* key in changedKeys) {
-                                                          [defaults setObject:[cloud objectForKey:key] forKey:key];
+                                                      
+                                                      NSDictionary* userInfo = [notification userInfo];
+                                                      NSNumber* reasonForChange = [userInfo objectForKey:NSUbiquitousKeyValueStoreChangeReasonKey];
+                                                      
+                                                      // If a reason could not be determined, do not update anything.
+                                                      if (!reasonForChange)
+                                                      return;
+                                                      
+                                                      // Update only for changes from the server.
+                                                      NSInteger reason = [reasonForChange integerValue];
+                                                      if ((reason == NSUbiquitousKeyValueStoreServerChange) ||
+                                                          (reason == NSUbiquitousKeyValueStoreInitialSyncChange)) {
+                                                          NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+                                                          NSUbiquitousKeyValueStore* cloud = [NSUbiquitousKeyValueStore defaultStore];
+                                                          NSArray* changedKeys = [userInfo objectForKey:NSUbiquitousKeyValueStoreChangedKeysKey];
+                                                          for (NSString* key in changedKeys) {
+                                                              [defaults setObject:[cloud objectForKey:key] forKey:key];
+                                                          }
                                                       }
                                                   }];
-
+    
 }
 
 +(void)removeNotifications {


### PR DESCRIPTION
I noticed two differences from the Apple documentation in the notification handler:
- The reason for change shouldn't be ignored
- A datatype was incorrect
